### PR TITLE
Generate stub data based on a type name

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,45 @@ expect(result, "to satisfy", {
 
 Notice `min` defaults to 0 and `max` defaults to 10, so can just call the list function without any arguments, or only send in either `min` or `max`.
 
+## Generating stub types
+
+You can ask for a type by name the following way:
+
+```js
+let author = mock.getType("Author", 42);
+expect(author, "to satisfy", {
+  id: 42,
+  firstName: "herubju",
+  lastName: "nocpebe",
+  email: "ketis@ziluwi.cw",
+  favoritePost: {
+    id: "4945079106011136",
+    title: "kelecse",
+    author: {
+      id: "6325555974635520",
+      firstName: "jeminode",
+      lastName: "orimipon",
+      email: "dabinalut@wepmevagi.gb",
+    },
+    votes: 13,
+  },
+});
+```
+
+You can control the likelihood of optional fields being included using the `likelihood` options that takes a percentage. Default likelihood is `80`.
+
+You can also control the recursion depth using the `depth` option. Default depth is 2.
+
+```js
+author = mock.getType("Author", 42, { depth: 1, likelihood: 30 });
+expect(author, "to equal snapshot", {
+  __typename: "Author",
+  id: 42,
+  firstName: "herubju",
+  lastName: "nocpebe",
+});
+```
+
 ## Providing custom resolvers
 
 It is possible to create a custom resolver that can use the mock store to retrieve or update the stored mocks.

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,11 @@
 const { makeExecutableSchema } = require("@graphql-tools/schema");
-const { addMocksToSchema, MockList } = require("@graphql-tools/mock");
+
+const {
+  addMocksToSchema,
+  createMockStore,
+  MockList,
+} = require("@graphql-tools/mock");
+
 const { graphql, print } = require("graphql");
 const merge = require("lodash/merge");
 const mergeWith = require("lodash/mergeWith");
@@ -15,6 +21,9 @@ const list =
     return new MockList(length);
   };
 
+const isRef = (value) => value && value.$ref;
+const isRefArray = (value) => Array.isArray(value) && value.some(isRef);
+
 class GraphQLMock {
   constructor({ typeDefs, mocks, resolvers, seed = 666 }) {
     const schema = makeExecutableSchema({
@@ -22,7 +31,8 @@ class GraphQLMock {
       resolverValidationOptions: { requireResolversForResolveType: false },
     });
 
-    const defaultChance = new Chance(seed);
+    this._cache = new Map();
+    this._chance = new Chance(seed);
 
     const defaultMocks = {
       Boolean: (chance) => chance.bool(),
@@ -37,48 +47,112 @@ class GraphQLMock {
       ...(Array.isArray(mocks) ? mocks : [mocks]).filter(Boolean),
     ];
 
+    const mergedMocks = mergeWith(
+      ...mockArray.map((mocks) => {
+        Object.keys(mocks).forEach((key) => {
+          const mock = mocks[key];
+
+          if (typeof mock === "function") {
+            const chance = new Chance(this._chance.natural());
+
+            mocks[key] = (root, args, context, info) =>
+              mock(chance, root, args, context, info);
+          } else {
+            mocks[key] = (root, args, context, info) => mock;
+          }
+        });
+
+        return mocks;
+      }),
+      (a, b) => {
+        if (a && b) {
+          return (...args) => {
+            const aResult = a(...args);
+            const bResult = b(...args);
+
+            if (bResult === null) {
+              return bResult;
+            }
+
+            if (Array.isArray(bResult)) {
+              return bResult;
+            }
+
+            return merge(aResult, bResult);
+          };
+        }
+
+        return b || a;
+      }
+    );
+
+    this.mockStore = createMockStore({
+      schema,
+      mocks: mergedMocks,
+    });
+
     this.schema = addMocksToSchema({
       schema,
       resolvers,
-      mocks: mergeWith(
-        ...mockArray.map((mocks) => {
-          Object.keys(mocks).forEach((key) => {
-            const mock = mocks[key];
-
-            if (typeof mock === "function") {
-              const chance = new Chance(defaultChance.natural());
-
-              mocks[key] = (root, args, context, info) =>
-                mock(chance, root, args, context, info);
-            } else {
-              mocks[key] = (root, args, context, info) => mock;
-            }
-          });
-
-          return mocks;
-        }),
-        (a, b) => {
-          if (a && b) {
-            return (...args) => {
-              const aResult = a(...args);
-              const bResult = b(...args);
-
-              if (bResult === null) {
-                return bResult;
-              }
-
-              if (Array.isArray(bResult)) {
-                return bResult;
-              }
-
-              return merge(aResult, bResult);
-            };
-          }
-
-          return b || a;
-        }
-      ),
+      store: this.mockStore,
+      mocks: mergedMocks,
     });
+  }
+
+  _resolveRef(value, options) {
+    if (isRef(value)) {
+      return this.getType(value.$ref.typeName, value.$ref.key, options);
+    } else {
+      return value;
+    }
+  }
+
+  getType(typeName, key, { depth = 2, likelihood = 80 } = {}) {
+    const cacheKey = `${typeName}:${key}:${depth}:${likelihood}`;
+
+    if (this._cache.has(cacheKey)) {
+      return this._cache.get(cacheKey);
+    }
+
+    const type = this.schema.getType(typeName);
+
+    if (!type) {
+      throw new Error(`Unknown type: ${typeName}`);
+    }
+
+    const fields = type.getFields();
+
+    const result = { __typename: typeName };
+
+    for (const [fieldName, field] of Object.entries(fields)) {
+      if (
+        field.type.toString().endsWith("!") ||
+        this._chance.bool({ likelihood })
+      ) {
+        const stubbedField = this.mockStore.get(type.name, key, fieldName);
+
+        if (isRefArray(stubbedField)) {
+          if (depth > 0) {
+            result[fieldName] = stubbedField.map((value) =>
+              this._resolveRef(value, { depth: depth - 1, likelihood })
+            );
+          }
+        } else if (isRef(stubbedField)) {
+          if (depth > 0) {
+            result[fieldName] = this._resolveRef(stubbedField, {
+              depth: depth - 1,
+              likelihood,
+            });
+          }
+        } else {
+          result[fieldName] = stubbedField;
+        }
+      }
+    }
+
+    this._cache.set(cacheKey, result);
+
+    return result;
   }
 
   execute(query, variables) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -7,10 +7,11 @@ const { GraphQLMock, list } = require("../src/index.js");
 const typeDefs = `
   type Author {
     id: ID!
-    firstName: String
-    lastName: String
+    firstName: String!
+    lastName: String!
     email: String
-    posts: [Post]
+    posts: [Post!]
+    favoritePost: Post
   }
 
   type Post {
@@ -306,6 +307,312 @@ describe("graphql-fakester", () => {
         }
       `
       );
+    });
+  });
+
+  describe("getType", () => {
+    beforeEach(async () => {
+      mock = new GraphQLMock({
+        typeDefs,
+        mocks: {
+          Author: (chance) => ({
+            email: chance.email(),
+            posts: list({ length: 3 }),
+          }),
+          Post: (chance) => ({
+            votes: chance.natural({ max: 100 }),
+          }),
+        },
+      });
+    });
+
+    it("throws when asked for an unknown type", () => {
+      expect(
+        () => {
+          mock.getType("MyUndefinedType");
+        },
+        "to throw",
+        "Unknown type: MyUndefinedType"
+      );
+    });
+
+    it("returns a stubbed version of the given type", () => {
+      const author = mock.getType("Author", 42);
+
+      expect(author, "to equal snapshot", {
+        __typename: "Author",
+        id: 42,
+        firstName: "herubju",
+        lastName: "nocpebe",
+        email: "ketis@ziluwi.cw",
+        favoritePost: {
+          __typename: "Post",
+          id: "4945079106011136",
+          title: "kelecse",
+          author: {
+            __typename: "Author",
+            id: "6325555974635520",
+            firstName: "jeminode",
+            lastName: "orimipon",
+            email: "dabinalut@wepmevagi.gb",
+          },
+          votes: 13,
+        },
+      });
+    });
+
+    describe("when asking for the same entity twice", () => {
+      describe("and the depth and likelihook is the same", () => {
+        it("returns the same object", () => {
+          expect(
+            mock.getType("Author", 42),
+            "to be",
+            mock.getType("Author", 42)
+          );
+        });
+      });
+
+      describe("and the depth is different", () => {
+        it("returns a new object", () => {
+          expect(
+            mock.getType("Author", 42),
+            "not to be",
+            mock.getType("Author", 42, { depth: 3 })
+          );
+        });
+      });
+
+      describe("and the likelihook is different", () => {
+        it("returns a new object", () => {
+          expect(
+            mock.getType("Author", 42),
+            "not to be",
+            mock.getType("Author", 42, { likelihood: 30 })
+          );
+        });
+      });
+    });
+
+    it("uses the given id", () => {
+      const author = mock.getType("Author", 42);
+
+      expect(author, "to satisfy", { id: 42 });
+    });
+
+    describe("when given a depth", () => {
+      it("stubs to the depth", () => {
+        const author = mock.getType("Author", 42, { depth: 4 });
+
+        expect(author, "to equal snapshot", {
+          __typename: "Author",
+          id: 42,
+          firstName: "herubju",
+          lastName: "nocpebe",
+          email: "ketis@ziluwi.cw",
+          favoritePost: {
+            __typename: "Post",
+            id: "4945079106011136",
+            title: "kelecse",
+            author: {
+              __typename: "Author",
+              id: "6325555974635520",
+              firstName: "jeminode",
+              lastName: "orimipon",
+              email: "dabinalut@wepmevagi.gb",
+              posts: [
+                {
+                  __typename: "Post",
+                  id: "308014672248832",
+                  title: "rurzilru",
+                  author: {
+                    __typename: "Author",
+                    id: "4158848130613248",
+                    firstName: "lufzipav",
+                    lastName: "bujledol",
+                    email: "bihac@su.cr",
+                  },
+                  votes: 14,
+                },
+                {
+                  __typename: "Post",
+                  id: "1702188611010560",
+                  title: "jonubzov",
+                  author: {
+                    __typename: "Author",
+                    id: "8977495304962048",
+                    firstName: "ocomohi",
+                    lastName: "widdivew",
+                    email: "zem@fad.be",
+                  },
+                  votes: 61,
+                },
+                {
+                  __typename: "Post",
+                  id: "1828976169320448",
+                  title: "zapugjeg",
+                  author: {
+                    __typename: "Author",
+                    id: "3264289079033856",
+                    firstName: "jatafose",
+                    lastName: "gorogef",
+                    email: "tohuh@vi.bh",
+                  },
+                  votes: 60,
+                },
+              ],
+              favoritePost: {
+                __typename: "Post",
+                id: "8817102102200320",
+                title: "babucus",
+                author: {
+                  __typename: "Author",
+                  id: "4255354269466624",
+                  firstName: "dolira",
+                  lastName: "kejipure",
+                },
+                votes: 26,
+              },
+            },
+          },
+        });
+      });
+    });
+
+    describe("when given a likelihood of zero", () => {
+      it("only includes required fields", () => {
+        const author = mock.getType("Author", 42, { likelihood: 0 });
+
+        expect(author, "to equal snapshot", {
+          __typename: "Author",
+          id: 42,
+          firstName: "herubju",
+          lastName: "nocpebe",
+        });
+      });
+    });
+
+    describe("when given a likelihood of 100", () => {
+      it("includes all fields while respecting the depth", () => {
+        const author = mock.getType("Author", 42, {
+          depth: 1,
+          likelihood: 100,
+        });
+
+        expect(author, "to equal snapshot", {
+          __typename: "Author",
+          id: 42,
+          firstName: "herubju",
+          lastName: "nocpebe",
+          email: "ketis@ziluwi.cw",
+          posts: [
+            {
+              __typename: "Post",
+              id: "4945079106011136",
+              title: "kelecse",
+              votes: 13,
+            },
+            {
+              __typename: "Post",
+              id: "6325555974635520",
+              title: "jeminode",
+              votes: 27,
+            },
+            {
+              __typename: "Post",
+              id: "308014672248832",
+              title: "orimipon",
+              votes: 25,
+            },
+          ],
+          favoritePost: {
+            __typename: "Post",
+            id: "4620302535360512",
+            title: "rurzilru",
+            votes: 73,
+          },
+        });
+      });
+    });
+
+    describe("when given a likelihood", () => {
+      it("includes optional fields based on that likelihood", () => {
+        const author = mock.getType("Author", 42, { likelihood: 100 });
+
+        expect(author, "to equal snapshot", {
+          __typename: "Author",
+          id: 42,
+          firstName: "herubju",
+          lastName: "nocpebe",
+          email: "ketis@ziluwi.cw",
+          posts: [
+            {
+              __typename: "Post",
+              id: "4945079106011136",
+              title: "kelecse",
+              author: {
+                __typename: "Author",
+                id: "1702188611010560",
+                firstName: "jeminode",
+                lastName: "orimipon",
+                email: "dabinalut@wepmevagi.gb",
+              },
+              votes: 13,
+            },
+            {
+              __typename: "Post",
+              id: "6325555974635520",
+              title: "rurzilru",
+              author: {
+                __typename: "Author",
+                id: "5223687156400128",
+                firstName: "lufzipav",
+                lastName: "bujledol",
+                email: "dowwipwo@dib.ma",
+              },
+              votes: 27,
+            },
+            {
+              __typename: "Post",
+              id: "308014672248832",
+              title: "jonubzov",
+              author: {
+                __typename: "Author",
+                id: "494041963692032",
+                firstName: "ocomohi",
+                lastName: "widdivew",
+                email: "be@tesih.bn",
+              },
+              votes: 25,
+            },
+          ],
+          favoritePost: {
+            __typename: "Post",
+            id: "4255354269466624",
+            title: "zapugjeg",
+            author: {
+              __typename: "Author",
+              id: "2941350620168192",
+              firstName: "jatafose",
+              lastName: "gorogef",
+              email: "asmedum@vudsufsa.ga",
+            },
+            votes: 26,
+          },
+        });
+      });
+    });
+
+    describe("when given both a depth and a likelihood", () => {
+      it("includes optional fields based on that likelihood to the given depth", () => {
+        const author = mock.getType("Author", 42, { depth: 1, likelihood: 30 });
+
+        expect(author, "to equal snapshot", {
+          __typename: "Author",
+          id: 42,
+          firstName: "herubju",
+          lastName: "nocpebe",
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
## Generating stub types

You can ask for a type by name the following way:

```js
let author = mock.getType("Author", 42);
expect(author, "to satisfy", {
  id: 42,
  firstName: "herubju",
  lastName: "nocpebe",
  email: "ketis@ziluwi.cw",
  favoritePost: {
    id: "4945079106011136",
    title: "kelecse",
    author: {
      id: "6325555974635520",
      firstName: "jeminode",
      lastName: "orimipon",
      email: "dabinalut@wepmevagi.gb",
    },
    votes: 13,
  },
});
```

You can control the likelihood of optional fields being included using the `likelihood` options that takes a percentage. Default likelihood is `80`.

You can also control the recursion depth using the `depth` option. Default depth is 2.

```js
author = mock.getType("Author", 42, { depth: 1, likelihood: 30 });
expect(author, "to equal snapshot", {
  __typename: "Author",
  id: 42,
  firstName: "herubju",
  lastName: "nocpebe",
});
```