### PR TITLE
Fix providing a function to override a top-level Query resolver (Major)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -126,7 +126,7 @@ class GraphQLMock {
 
       return [
         type.name,
-        (variables, parent, ...other) => {
+        (variables) => {
           const data = type.args
             ? mock(chance, variables, seq++)
             : mock(chance, seq++);

--- a/src/index.js
+++ b/src/index.js
@@ -126,8 +126,7 @@ class GraphQLMock {
 
       return [
         type.name,
-        (variables) => {
-          // FIXME
+        (variables, parent, ...other) => {
           const data = type.args
             ? mock(chance, variables, seq++)
             : mock(chance, seq++);

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -464,6 +464,7 @@ describe("graphql-fakester", () => {
       describe("by providing a function", () => {
         const authorNameQuery = `
           query authorFirstName($id: ID!) {
+            randomInt
             author(id: $id) {
               id
               firstName
@@ -476,7 +477,8 @@ describe("graphql-fakester", () => {
             typeDefs,
             mocks: {
               Query: {
-                author: (id) => ({
+                randomInt: 0,
+                author: (chance, { id }) => ({
                   id,
                   firstName: "Alice",
                 }),
@@ -486,12 +488,37 @@ describe("graphql-fakester", () => {
         });
 
         it("returns the mocked author", async () => {
-          const result = await mock.execute(authorNameQuery, { id: "10" });
+          const result = await mock.execute(authorNameQuery, { id: "12" });
 
           expect(
             result,
             "to inspect as snapshot",
-            "{ data: { author: { id: '10', firstName: 'Alice' } } }"
+            "{ data: { randomInt: 0, author: { id: '12', firstName: 'Alice', __typename: 'Author' } } }"
+          );
+        });
+      });
+
+      describe("when providing invalid resolvers", () => {
+        it("throws an error for unknown resolvers", async () => {
+          expect(
+            () => {
+              // eslint-disable-next-line no-new
+              new GraphQLMock({
+                typeDefs,
+                mocks: {
+                  Query: {
+                    randomInt: 0,
+                    author: (chance, { id }) => ({
+                      id,
+                      firstName: "Alice",
+                    }),
+                    unknownResolver: () => 10,
+                  },
+                },
+              });
+            },
+            "to throw",
+            "Trying to override unknown field Query.unknownResolver"
           );
         });
       });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -461,6 +461,45 @@ describe("graphql-fakester", () => {
         });
       });
 
+      describe("by providing a function for Mutation", () => {
+        const upvotePostMutation = `
+          mutation upvotePost($postId: ID!) {
+            upvotePost(postId: $postId) {
+              id
+              title
+              votes
+            }
+          }
+        `;
+
+        beforeEach(() => {
+          mock = new GraphQLMock({
+            typeDefs,
+            mocks: {
+              Mutation: {
+                upvotePost: (chance, { postId }) => ({
+                  id: postId,
+                  title: "Post Title",
+                  votes: 55,
+                }),
+              },
+            },
+          });
+        });
+
+        it("returns the mocked upvoted post", async () => {
+          const result = await mock.execute(upvotePostMutation, {
+            postId: "random-id",
+          });
+
+          expect(
+            result,
+            "to inspect as snapshot",
+            `{ data: { upvotePost: { id: 'random-id', title: 'Post Title', votes: 55, __typename: 'Post' } } }`
+          );
+        });
+      });
+
       describe("by providing a function", () => {
         const authorNameQuery = `
           query authorFirstName($id: ID!) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -397,27 +397,59 @@ describe("graphql-fakester", () => {
     });
 
     describe("mocking a resolver on an object", () => {
-      beforeEach(() => {
-        mock = new GraphQLMock({
-          typeDefs,
-          mocks: {
-            Query: {
-              randomInt: 0,
+      describe("by using a static value", () => {
+        beforeEach(() => {
+          mock = new GraphQLMock({
+            typeDefs,
+            mocks: {
+              Query: {
+                randomInt: 0,
+              },
             },
-          },
+          });
         });
-      });
 
-      const randomIntQuery = `
+        const randomIntQuery = `
         query randomIntQuery {
           randomInt
         }
       `;
 
-      it("uses the provided result will be used", async () => {
-        const result = await mock.execute(randomIntQuery);
+        it("uses the provided result will be used", async () => {
+          const result = await mock.execute(randomIntQuery);
 
-        expect(result, "to inspect as snapshot", "{ data: { randomInt: 0 } }");
+          expect(
+            result,
+            "to inspect as snapshot",
+            "{ data: { randomInt: 0 } }"
+          );
+        });
+      });
+
+      describe("by providing a function", () => {
+        beforeEach(() => {
+          mock = new GraphQLMock({
+            typeDefs,
+            mocks: {
+              Query: {
+                author: (id) => ({
+                  id,
+                  firstName: "Alice",
+                }),
+              },
+            },
+          });
+        });
+
+        it("returns the mocked author", async () => {
+          const result = await mock.execute(authorQuery, { id: "10" });
+
+          expect(
+            result,
+            "to inspect as snapshot",
+            "{ data: { author: { id: '10', firstName: 'Alice' } } }"
+          );
+        });
       });
     });
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -426,7 +426,51 @@ describe("graphql-fakester", () => {
         });
       });
 
+      describe("by providing a function for Query", () => {
+        const authorNameQuery = `
+          query authorFirstName($id: ID!) {
+            author(id: $id) {
+              id
+              firstName
+            }
+          }
+        `;
+
+        beforeEach(() => {
+          mock = new GraphQLMock({
+            typeDefs,
+            mocks: {
+              Query: () => ({
+                author: {
+                  id: authorId,
+                  firstName: "Alice",
+                },
+              }),
+            },
+          });
+        });
+
+        it("returns the mocked author", async () => {
+          const result = await mock.execute(authorNameQuery, { id: "10" });
+
+          expect(
+            result,
+            "to inspect as snapshot",
+            "{ data: { author: { id: '6', firstName: 'Alice', __typename: 'Author' } } }"
+          );
+        });
+      });
+
       describe("by providing a function", () => {
+        const authorNameQuery = `
+          query authorFirstName($id: ID!) {
+            author(id: $id) {
+              id
+              firstName
+            }
+          }
+        `;
+
         beforeEach(() => {
           mock = new GraphQLMock({
             typeDefs,
@@ -442,7 +486,7 @@ describe("graphql-fakester", () => {
         });
 
         it("returns the mocked author", async () => {
-          const result = await mock.execute(authorQuery, { id: "10" });
+          const result = await mock.execute(authorNameQuery, { id: "10" });
 
           expect(
             result,


### PR DESCRIPTION
Currently, when providing an override for a top-level Query resolver that is a function, it fails:

```
Query: {
    author: (id) => ({
      id,
      firstName: "Alice",
    }),
  },
 ```

Breaking changes: 

- mock resolvers gets the arguments when they are available, so if you where using a resolver mock that accepts `chance` and an index, you will now get the `args` as the second parameter. 